### PR TITLE
system / fix flashmessenger warning / cannot mix flashMessenger() args

### DIFF
--- a/usr/module/system/src/Controller/Admin/IndexController.php
+++ b/usr/module/system/src/Controller/Admin/IndexController.php
@@ -29,7 +29,7 @@ class IndexController extends ActionController
         // Security check for setup folder
         if (is_dir(Pi::path('setup'))) {
             $pattern = _a('Security: `setup` folder is not removed!');
-            $this->flashMessenger($pattern, 'warning');
+            $this->flashMessenger($pattern, 'error');
         }
 
         // Security check for boot file


### PR DESCRIPTION
https://github.com/pi-engine/pi/commit/f57f86003126f5256b5b6a0280a9b7978e28032b
: improved code readability but added a regression on message display. Only first check is displayed.
In the same class, we can not mix error and warning  :  it breaks the clas{} returned message
display => i revert from "warning" to "error" to have consistency with other security checks.
