### PR TITLE
Add extea meta tags

### DIFF
--- a/lib/Pi/View/Helper/Ga.php
+++ b/lib/Pi/View/Helper/Ga.php
@@ -70,7 +70,7 @@ class Ga extends AbstractHelper
 EOT;
 
         $scripts = sprintf($gaScripts, $trackingId, $host);
-        $this->view->headScript()->appendScript($scripts);
+        $this->view->footScript()->appendScript($scripts);
 
         return $this;
     }

--- a/lib/Pi/View/Helper/ThemeAssemble.php
+++ b/lib/Pi/View/Helper/ThemeAssemble.php
@@ -126,17 +126,67 @@ class ThemeAssemble extends AbstractHelper
             $headMeta->appendName($key, $meta);
         }
 
-        // Dublin Core
+        // Get informations
         $sitename = Pi::config('sitename');
         $slogan = Pi::config('slogan');
-        $locale = Pi::service('i18n')->getLocale();
         $description = Pi::config('description');
+        $locale = Pi::service('i18n')->getLocale();
+        $ogLocale = Pi::config('og_local');
+        $twitter = Pi::config('twitter_account');
+        $facebook = Pi::config('facebook_appid');
+        $pinterest = Pi::config('pinterest_verify');
+        $geoLatitude = Pi::config('geo_latitude');
+        $geoLongitudet = Pi::config('geo_longitude');
+        $geoPlacename = Pi::config('geo_placename');
+        $geoRegion = Pi::config('geo_region');
+
+        // Meta author and generator
+        $headMeta($sitename, 'author');
+        $headMeta($sitename, 'generator');
+
+        // Dublin Core
         $headMeta($sitename, 'dc:title', 'property', array('lang' => $locale));
         $headMeta($slogan, 'dc:subject', 'property', array('lang' => $locale));
         $headMeta($description, 'dc:description', 'property', array('lang' => $locale));
         $headMeta('text', 'dc:type', 'property');
         $headMeta($sitename, 'dc:publisher', 'property');
         $headMeta($locale, 'dc:language', 'property');
+
+        // Open Graph
+        $headMeta($sitename, 'og:title', 'property');
+        $headMeta($sitename, 'og:site_name', 'property');
+        $headMeta($description, 'og:description', 'property');
+        $headMeta(Pi::url(), 'og:url', 'property');
+        $headMeta($ogLocale, 'og:locale', 'property');
+        $headMeta('website', 'og:type', 'property');
+        $headMeta(Pi::service('asset')->logo(), 'og:image', 'property');
+        
+        // Facebook
+        if (!empty($facebook)) {
+            $headMeta($facebook, 'fb:app_id', 'property');
+        }
+        
+        // Twitter Cards
+        if (!empty($twitter)) {
+            $headMeta('summary', 'twitter:card');
+            $headMeta($twitter, 'twitter:site');
+            $headMeta($twitter, 'twitter:creator');
+            $headMeta($sitename, 'twitter:title');
+            $headMeta($description, 'twitter:description');
+            $headMeta(Pi::service('asset')->logo(), 'twitter:image');
+            $headMeta(Pi::url(), 'twitter:domain');
+            $headMeta(Pi::url(), 'twitter:url');
+        }
+
+        // Pinterest
+        if (!empty($pinterest)) {
+            $headMeta($pinterest, 'p:domain_verify');
+        }
+        
+        // Geo tags
+        if (!empty($geoLatitude) && !empty($geoLongitudet)) {
+            $this->view->geoTag($geoLatitude, $geoLongitudet, $geoPlacename, $geoRegion);
+        }
     }
 
     /**

--- a/usr/module/system/config/config.php
+++ b/usr/module/system/config/config.php
@@ -25,6 +25,14 @@ $config['category'] = array(
         'title'     => _t('Head meta'),
     ),
     array(
+        'name'      => 'head_meta_extra',
+        'title'     => _t('Extra head meta'),
+    ),
+    array(
+        'name'      => 'geo_tag',
+        'title'     => _t('Geo tags'),
+    ),
+    array(
         'name'      => 'intl',
         'title'     => _t('Internationalization'),
     ),
@@ -578,6 +586,78 @@ $config['item'] = array(
         'visible'       => 0,
     ),
 
+    'author'        => array(
+        'title'         => '`author`',
+        'description'   => _t('The author meta tag defines the name of the author of the document being read. Supported data formats include the name, email address of the webmaster, company name or URL.'),
+        'edit'          => 'text',
+        'value'         => 'Pi Engine',
+        'category'      => 'head_meta_extra',
+    ),
+
+    'generator'     => array(
+        'title'         => '`generator`',
+        'description'   => _t('Generator of the document being read.'),
+        'edit'          => 'text',
+        'value'         => 'Pi Engine',
+        'category'      => 'head_meta_extra',
+    ),
+
+    'og_local'      => array(
+        'title'         => _t('Website local'),
+        'description'   => _t('Set website local, like en_GB'),
+        'edit'          => 'text',
+        'value'         => 'en_GB',
+        'category'      => 'head_meta_extra',
+    ),
+
+    'twitter_account'   => array(
+        'title'         => _t('Twitter account'),
+        'description'   => _t('Username for the website used in the card footer. Add @ before username like @PiEnable or leave it empty'),
+        'edit'          => 'text',
+        'category'      => 'head_meta_extra',
+    ),
+
+    'facebook_appid'   => array(
+        'title'         => _t('Facebook app id'),
+        'description'   => _t('Set facebook app id here for use open graph tags on facebook page, its your website facebook page id'),
+        'edit'          => 'text',
+        'category'      => 'head_meta_extra',
+    ),
+
+    'pinterest_verify'   => array(
+        'title'         => _t('Pinterest domain verify'),
+        'description'   => _t('Set pinterest domain verify code here, if your website have page on pinterest'),
+        'edit'          => 'text',
+        'category'      => 'head_meta_extra',
+    ),
+
+    'geo_latitude'   => array(
+        'title'         => _t('Latitude'),
+        'description'   => '',
+        'edit'          => 'text',
+        'category'      => 'geo_tag',
+    ),
+
+    'geo_longitude'   => array(
+        'title'         => _t('Longitude'),
+        'description'   => '',
+        'edit'          => 'text',
+        'category'      => 'geo_tag',
+    ),
+
+    'geo_placename'   => array(
+        'title'         => _t('Placename'),
+        'description'   => '',
+        'edit'          => 'text',
+        'category'      => 'geo_tag',
+    ),
+
+    'geo_region'   => array(
+        'title'         => _t('Region'),
+        'description'   => '',
+        'edit'          => 'text',
+        'category'      => 'geo_tag',
+    ),
 );
 
 return $config;

--- a/usr/module/system/config/module.php
+++ b/usr/module/system/config/module.php
@@ -21,7 +21,7 @@ return array(
         'description'   =>
             _a('For administration of core functions of the site.'),
         // Version number, required
-        'version'       => '3.5.1',
+        'version'       => '3.5.2',
         // Distribution license, required
         'license'       => 'New BSD',
         // Logo image, for admin, optional


### PR DESCRIPTION
I suggest this two changes , I add two new config category and add some new cofings , now we can manage ogtags for facebook page , twitter card and valid pintrest page , and if website have localtion we can support get tags for location on all pages

all of this options can be customize on module pages, for example I add on custom tags and twitter card informations for eah page on news / shop and guide modules 