### PR TITLE
fix typo in image driver lib calling for gmagik, reverse driver order

### DIFF
--- a/lib/Pi/Application/Service/Image.php
+++ b/lib/Pi/Application/Service/Image.php
@@ -215,17 +215,17 @@ class Image extends AbstractService
                     break;
                 case 'imagick':
                     if (class_exists('Imagick')) {
-                        $driverClass = 'Imagine\Gmagick\Imagine';
+                        $driverClass = 'Imagine\Imagick\Imagine';
                     }
                     break;
                 case 'auto':
                 default:
-                    if (function_exists('gd_info')) {
-                        $driverClass = 'Imagine\Gd\Imagine';
-                    } elseif (class_exists('Gmagick')) {
+                    if (class_exists('Gmagick')) {
                         $driverClass = 'Imagine\Gmagick\Imagine';
                     } elseif (class_exists('Imagick')) {
-                        $driverClass = 'Imagine\Gmagick\Imagine';
+                        $driverClass = 'Imagine\Imagick\Imagine';
+                    } elseif (function_exists('gd_info')) {
+                        $driverClass = 'Imagine\Gd\Imagine';
                     }
                     break;
             }


### PR DESCRIPTION
* fix typo
* reverse driver use : prefer performance and quality. Put GD latest if no
better lib is available/installed.
* GD generates the worst image (quality wise) and has memory leaks.
* ImageMagick keeps quality, EXIF information and color profiles.
* Gmagik is a fork over Imagick (better performance). 
* Generaly Imagick or GD are installed. Imagick supersedes GD on many points.
